### PR TITLE
feat: add internal conversation endpoint; add db migration step; add …

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: FastAPI Dev",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/.venv/bin/fastapi",
+      "args": [
+        "dev",
+        "main.py"
+      ],
+      "env": {
+        "GOOGLE_API_KEY": ""
+      }
+    }
+  ]
+}

--- a/handler/routes.py
+++ b/handler/routes.py
@@ -27,7 +27,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         token = request.headers.get("Authorization")
-        if request.url.path.__contains__("/login"):
+        if request.url.path.__contains__("/login") or request.url.path.__contains__("/internal"):
             self.__logger.info(f"path={request.url.path} method={request.method} client_ip={request.client.host}")
             return await call_next(request)
         if token is None:
@@ -170,7 +170,6 @@ class Routes:
             api_key: Annotated[str | None, Header()] = None,
             ):
             try:
-                print(f"api key: {api_key}")
                 if api_key is None:
                     raise UnauthorizedAccess("API key is required")
                 self.user_usecase.get_api_key(username=request.state.user, api_key=api_key)
@@ -332,7 +331,59 @@ class Routes:
             except Exception as e:
                 self.logger.error(str(e))
                 raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str("internal server error"))
+            
+        @self.app.post("/v1/internal/conversation")
+        async def create_internal_chat_session(
+            request: Request,
+            api_key: Annotated[str,  Header()],
+            project_id: Annotated[str,  Form()],
+            conversation_uuid: Annotated[str, Form()],
+            message: Annotated[str, Form()],
+            username: Annotated[str | None, Header()] = None,
+            files: List[UploadFile] | None = None,
+        ):
+            try:
+                if username is None:
+                    username = ""
+                    self.user_usecase.get_api_key_internal(api_key=api_key)
+                else:
+                    self.user_usecase.get_api_key(username=username, api_key=api_key)
+                conversation = Conversation(
+                    project_id=project_id,
+                    conversation_uuid=conversation_uuid,
+                    message=message,
+                    tenant_id=username,
+                )
+                if files is not None:
+                    __check_file_validity(files)
+                    for file in files:
+                        document = Document(file=file)
+                        document.set_multinancy_attr(project_uuid=project_id, tenant_id=username)
+                        document_db = self.document_usecase.store_document(document=document)
+                        langchain_document = await self.document_usecase.document_vectorization(document=document_db)
+                        conversation.document_from_user.extend(langchain_document)
 
+                conversation.project_id = project_id
+                conversation.tenant_id = username
+                response, req_token, res_token = self.conversation_usecase.chat_with_agent(conversation=conversation)
+                request.state.req_token = req_token
+                request.state.res_token = res_token
+                return Response(content=response)
+            except UnauthorizedAccess as e:
+                self.logger.error(str(e))
+                raise HTTPException(status.HTTP_403_FORBIDDEN, "unauthorized access, please provide valid API key")
+            except ResourceNotFound as e:
+                self.logger.error(str(e))
+                raise HTTPException(status.HTTP_404_NOT_FOUND, str(e))
+            except FileTooLarge as e:
+                self.logger.error(str(e))
+                raise HTTPException(status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, str(e))
+            except UnknownFileType as e:
+                self.logger.error(str(e))
+                raise HTTPException(status.HTTP_400_BAD_REQUEST, str(e))
+            except Exception as e:
+                self.logger.error(str(e))
+                raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR, "please try again later")
 
 
         @self.app.get("/")

--- a/repository/user.py
+++ b/repository/user.py
@@ -44,8 +44,25 @@ class UserRepository:
                 result = conn.execute(sql, data).fetchone()
                 if result is None:
                     raise ResourceNotFound("API key not found for user")
-                api_key: str = result
-                return api_key
+                api_key_from_db: str = result
+                return api_key_from_db
+            except ResourceNotFound as e:
+                self.logger.error(str(e))
+                raise 
+            except Exception as e:
+                self.logger.error(str(e))
+                raise DatabaseError("database has error when querying API key")
+            
+    def get_api_key_internal(self, api_key: str):
+        with self.__db_adapter.get_connection() as conn:
+            sql = "SELECT api_key FROM api_keys WHERE api_key = %s LIMIT 1"
+            data = (api_key,)
+            try:
+                result = conn.execute(sql, data).fetchone()
+                if result is None:
+                    raise ResourceNotFound("API key not found")
+                api_key_from_db: str = result
+                return api_key_from_db
             except ResourceNotFound as e:
                 self.logger.error(str(e))
                 raise 

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -29,3 +29,6 @@ CREATE TABLE IF NOT EXISTS api_keys (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     user_id bigint NOT NULL REFERENCES users(id);
 );
+
+-- 26072025: `documents` table no longer needs to assure consistency with `projects` table as it already validated on downstream application
+ALTER TABLE public.documents DROP CONSTRAINT documents_projects_uuid_fkey;

--- a/usecase/user.py
+++ b/usecase/user.py
@@ -56,6 +56,10 @@ class UserUsecase:
     def get_api_key(self, username: str, api_key: str) -> str:
         api_key = self.__user_repository.get_api_key(username=username, api_key=api_key)
         return api_key
+    
+    def get_api_key_internal(self,  api_key: str) -> str:
+        api_key = self.__user_repository.get_api_key_internal(api_key=api_key)
+        return api_key
         
         
 


### PR DESCRIPTION
Changes:
- Add internal conversation endpoint
- Alter `documents` table to delete foreign key to `projects` table as `documents` no longer needed to ensure consistency.
- Add debug tools for easier development

Notes:
- Added an optional `username` header at internal conversation endpoint. I just realized that we need to ensure that the `api_key` and the user are linked together. I choose to make it an optional header key to keep the contract we discuss at Thursday valid.